### PR TITLE
Hold power pin immediately after startup.

### DIFF
--- a/nRF5_SDK_12.3.0/components/libraries/bootloader/dfu/nrf_dfu.c
+++ b/nRF5_SDK_12.3.0/components/libraries/bootloader/dfu/nrf_dfu.c
@@ -146,9 +146,6 @@ uint32_t nrf_dfu_init()
 
     if(enter_bootloader_mode != 0 || !nrf_dfu_app_is_valid())
     {
-        /* Hold Power if we enter DFU */
-        nrf_gpio_pin_set(SYSTEM_POWER_HOLD__PIN);
-
         timers_init();
         scheduler_init();
 

--- a/src/main.c
+++ b/src/main.c
@@ -38,16 +38,16 @@ bool nrf_dfu_enter_check(void)
  */
 int main(void)
 {
-  /* TODO: After firmware update, start-up needs some seconds (~3 s) to boot into firmware.
-   * If you let the power button go during this time, firmware (or setting page?) gets corrupted and SW102 starts in DFU again.
-   */
-
   (void) NRF_LOG_INIT(NULL);
 
   nrf_gpio_cfg_input(BUTTON_M__PIN, NRF_GPIO_PIN_PULLUP);
   nrf_gpio_cfg_input(BUTTON_PWR__PIN, NRF_GPIO_PIN_NOPULL);
   nrf_gpio_cfg_output(SYSTEM_POWER_HOLD__PIN);
-  /* SYSTEM_POWER_HOLD__PIN triggers in nrf_dfu.c */
+
+  /* Hold Power immediately, otherwise bootloader processing may get interrupted if the user releases the power button too quickly.
+   * This effect is more pronounced if the firmware is small enough to trigger dual-bank DFU mode. */
+  nrf_gpio_pin_set(SYSTEM_POWER_HOLD__PIN);
+
 
   nrf_bootloader_init();
 


### PR DESCRIPTION
There is an issue with the current bootloader, which is actually mentioned in a comment main.c:

```
After firmware update, start-up needs some seconds (~3 s) to boot into firmware.
If you let the power button go during this time, firmware (or setting page?) gets corrupted and SW102 starts in DFU again.
```

The issue doesn't seem to manifest with the "official" open-source SW102 releases, likely because the firmware is large enough that two copies can't fit into the flash. In such case, the NRF DFU loader stores the uploaded firmware directly in the destination area in the flash. Otherwise, it would store it in a separate area, and then copy on the next boot, causing the delay - and if interrupted - it would corrupt the firmware.

This PR effectively forces the power to be supplied for the whole duration of the boot process. As a side-effect, the bike can be powered up by a short press of the power button.

side-note: I'm currently developing an alternate UI firmware for SW102 (aimed to be mostly compatible with the 1.1.0 release), which coincidentally is small enough to trigger this bug.